### PR TITLE
Fix: Update colorama to 0.4.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ typeguard==2.13.3
 cffi==1.15.0
 charset-normalizer==2.0.12
 click==8.1.7
-colorama==0.4.4
+colorama==0.4.6
 cycler==0.11.0
 decorator==5.1.1
 filelock==3.7.1


### PR DESCRIPTION
Updated colorama from 0.4.4 to 0.4.6 in requirements.txt to resolve dependency conflict with runpod package.