### PR TITLE
Fix: Add wget to Dockerfile for download.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxext6 \
     libxrender1 \
     git \
+    wget \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy the requirements file into the container


### PR DESCRIPTION
Added wget to the list of system dependencies installed via apt-get in the Dockerfile. This is required by the download.sh script to fetch models or other necessary files.