### PR TITLE
Fix: Correct SyntaxError in runpod_handler.py

### DIFF
--- a/runpod_handler.py
+++ b/runpod_handler.py
@@ -219,7 +219,7 @@ class VideoProcessor:
             cap = cv2.VideoCapture(video_file_path)
             width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
             height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-            fps = cap.get(cv2.CAP_PROP_FPS))
+            fps = cap.get(cv2.CAP_PROP_FPS)
             cap.release()
 
             # The core task execution


### PR DESCRIPTION
Removed an extra closing parenthesis on the line assigning `fps` using `cv2.CAP_PROP_FPS` in `runpod_handler.py`.